### PR TITLE
Use simulator name and version, as reported to cocotb via vpi

### DIFF
--- a/test/test_uvm.py
+++ b/test/test_uvm.py
@@ -85,6 +85,8 @@ def uvm_basic_top_test(dut):
 def uvm_phase_test(dut):
     uvm_root = UVMRoot.get()
     test_comp = CompPhaseTest('comp_phase_test', uvm_root)
+    clp = UVMCmdlineProcessor.get_inst()
+    print("tool=" + clp.get_tool_name() + " version=" + clp.get_tool_version())
     yield run_test()
     yield test_comp.m_done_event.wait()
     if not test_comp.all_done:

--- a/uvm/base/uvm_cmdline_processor.py
+++ b/uvm/base/uvm_cmdline_processor.py
@@ -57,7 +57,12 @@ class UVMCmdLineVerb:
 #
 
 def uvm_dpi_get_tool_name():
-    return "cocotb + iverilog"
+    # Return the simulator name, as reported by VPI
+    return cocotb.SIM_NAME
+
+def uvm_dpi_get_tool_version():
+    # Return the simulator version, as reported by VPI
+    return cocotb.SIM_VERSION
 
 def uvm_dpi_regcomp(match):
     rr = None


### PR DESCRIPTION
cocotb stores the simulator name and version, as reported via VPI. Use this as the UVM tool namd and version

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>