### PR TITLE
modify implementation of 'wait' in m_wait_for_arbitration_completed

### DIFF
--- a/src/uvm/seq/uvm_sequencer_base.py
+++ b/src/uvm/seq/uvm_sequencer_base.py
@@ -849,11 +849,10 @@ class UVMSequencerBase(UVMComponent):
             if self.arb_completed.exists(request_id):
                 self.arb_completed.delete(request_id)
                 return
-            self.m_event_value_changed.clear()
-            evt = self.m_event_value_changed.wait()
-            yield evt
-            if lock_arb_size != self.m_lock_arb_size:
-                break
+
+            while lock_arb_size == self.m_lock_arb_size:
+                yield self.m_event_value_changed.wait()
+                self.m_event_value_changed.clear()
         #endtask
         #
 


### PR DESCRIPTION
I ran into this issue while bringing up the basic_read_write_sequence example as a unit test. I'm not entirely sure why the same isn't seen when run with a simulator. However, based on looking at the SystemVerilog code, I feel there is an issue here.

Here's the original SystemVerilog code for reference:
```
task uvm_sequencer_base::m_wait_for_arbitration_completed(int request_id);
  int lock_arb_size;

  // Search the list of arb_wait_q, see if this item is done
  forever
    begin
      lock_arb_size  = m_lock_arb_size;

      if (arb_completed.exists(request_id)) begin
        arb_completed.delete(request_id);
        return;
      end
      wait (lock_arb_size != m_lock_arb_size);
    end
endtask
```
Note that the loop doesn't terminate when the value of m_lock_arb_size changes.

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>