### PR TITLE
Add some VHDL DUTs

### DIFF
--- a/test/examples/simple/MakefileCommon.mk
+++ b/test/examples/simple/MakefileCommon.mk
@@ -20,6 +20,8 @@ export PYTHONPATH
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES ?= $(MAKEDIR)/common_stub.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES ?= $(MAKEDIR)/common_stub.vhd
 else
     $(error "A valid value (verilog) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif

--- a/test/examples/simple/common_stub.vhd
+++ b/test/examples/simple/common_stub.vhd
@@ -1,0 +1,22 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity common_stub is
+  port (
+    signal clk : in std_ulogic;
+    signal rst : in std_ulogic);
+end common_stub;
+
+architecture bhv of common_stub is
+  signal word : natural;
+begin
+
+  process (clk, rst) begin
+    if rst = '0' then
+      word <= 0;
+    elsif rising_edge(clk) then
+      word <= word + 1;
+    end if;
+  end process;
+
+end bhv;

--- a/test/examples/simple/registers/models/fifo_reg/Makefile
+++ b/test/examples/simple/registers/models/fifo_reg/Makefile
@@ -37,9 +37,19 @@
 include ../../../MakefileCommon.mk
 PYTHONPATH := $(WPWD)/../../../../integrated:$(PYTHONPATH)
 
-VERILOG_SOURCES := $(WPWD)/dut.sv
+ifeq ($(TOPLEVEL_LANG),verilog)
+        VERILOG_SOURCES += $(WPWD)/dut.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+        VHDL_SOURCES += $(WPWD)/dut.vhd
+else
+    $(error "A valid value (verilog) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
 
 TOPLEVEL := dut
 MODULE   ?= tb_run
+
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    COMPILE_ARGS=-v93
+endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/examples/simple/registers/models/fifo_reg/dut.vhd
+++ b/test/examples/simple/registers/models/fifo_reg/dut.vhd
@@ -1,0 +1,107 @@
+--
+-- -------------------------------------------------------------
+--    Copyright 2004-2011 Synopsys, Inc.
+--    Copyright 2010 Mentor Graphics Corporation
+--    All Rights Reserved Worldwide
+--
+--    Licensed under the Apache License, Version 2.0 (the
+--    "License"); you may not use this file except in
+--    compliance with the License.  You may obtain a copy of
+--    the License at
+--
+--        http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in
+--    writing, software distributed under the License is
+--    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+--    CONDITIONS OF ANY KIND, either express or implied.  See
+--    the License for the specific language governing
+--    permissions and limitations under the License.
+-- -------------------------------------------------------------
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity dut is
+  generic (
+    BASE_ADDR : natural := 0);
+  port (
+    apb_pclk    : in  std_logic;
+    apb_paddr   : in  unsigned(31 downto 0);
+    apb_psel    : in  std_logic;
+    apb_penable : in  std_logic;
+    apb_pwrite  : in  std_logic;
+    apb_prdata  : out std_logic_vector(31 downto 0);
+    apb_pwdata  : in  std_logic_vector(31 downto 0);
+    rst         : in  std_logic
+    );
+
+end dut;
+
+architecture bhv of dut is
+  type t_fifo is array (0 to 8) of std_logic_vector(31 downto 0);
+  signal fifo : t_fifo;
+
+  signal w_idx    : natural;
+  signal r_idx    : natural;
+  signal used     : natural;
+  signal pr_data  : std_logic_vector(31 downto 0);
+  signal pr_addr  : unsigned(31 downto 0);
+  signal in_range : boolean;
+
+begin
+
+  process (apb_paddr)
+  begin
+    pr_addr  <= apb_paddr - BASE_ADDR;
+    in_range <= false;
+    if (apb_paddr - BASE_ADDR) < 16#100# then
+      in_range <= true;
+    end if;
+  end process;
+
+  process (apb_penable, apb_psel, apb_pwrite, in_range, pr_data)
+  begin
+    if (apb_psel = '1' and apb_penable = '1' and apb_pwrite = '0' and in_range) then
+      apb_prdata <= pr_data;
+    else
+      apb_prdata <= (others => 'Z');
+    end if;
+  end process;
+
+  process (apb_pclk, rst)
+  begin
+    if rst = '1' then
+      for idx in fifo'range loop
+        fifo(idx) <= (others => '0');
+      end loop;  -- idx
+      w_idx <= 0;
+      r_idx <= 0;
+      used  <= 0;
+    elsif rising_edge(apb_pclk) then
+      -- Wait for a SETUP+READ or ENABLE+WRITE cycle
+      if (apb_psel = '1' and apb_penable = apb_pwrite and pr_addr = 0) then
+        pr_data <= (others => '0');
+        if apb_pwrite = '1' then
+          if used /= 8 then
+            -- report "Writing";
+            fifo(w_idx) <= apb_pwdata;
+            w_idx       <= w_idx + 1;
+            used        <= used + 1;
+          end if;
+        else
+          if used /= 0 then
+            -- report "Reading";
+            pr_data     <= fifo(r_idx);
+            fifo(r_idx) <= (others => '0');  -- just for debug; not necessary
+            r_idx       <= r_idx + 1;
+            used        <= used - 1;
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+
+end bhv;

--- a/test/examples/simple/registers/vertical_reuse/Makefile
+++ b/test/examples/simple/registers/vertical_reuse/Makefile
@@ -43,6 +43,13 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     else
         VERILOG_SOURCES := $(WPWD)/sys_dut.sv
     endif
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+    ifeq ($(IMG),BLK)
+        VHDL_SOURCES += $(WPWD)/blk_dut.vhd
+    else
+        VHDL_SOURCES += $(WPWD)/blk_dut.vhd
+        VHDL_SOURCES += $(WPWD)/sys_dut.vhd
+    endif
 else
     $(error "A valid value (verilog) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
@@ -72,7 +79,7 @@ else
 endif
 
 ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-    COMPILE_ARGS=-gpg "PBASE_ADDR => 'h100"
+    COMPILE_ARGS=-gpg "BASE_ADDR => 'h100" -v93
 else
     ifeq ($(SIM), icarus)
         COMPILE_ARGS="-PBASE_ADDR='h100"

--- a/test/examples/simple/registers/vertical_reuse/blk_dut.sv
+++ b/test/examples/simple/registers/vertical_reuse/blk_dut.sv
@@ -1,16 +1,16 @@
-// 
+//
 // -------------------------------------------------------------
 //    Copyright 2004-2011 Synopsys, Inc.
 //    Copyright 2010 Mentor Graphics Corporation
 //    All Rights Reserved Worldwide
-// 
+//
 //    Licensed under the Apache License, Version 2.0 (the
 //    "License"); you may not use this file except in
 //    compliance with the License.  You may obtain a copy of
 //    the License at
-// 
+//
 //        http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in
 //    writing, software distributed under the License is
 //    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -18,7 +18,7 @@
 //    the License for the specific language governing
 //    permissions and limitations under the License.
 // -------------------------------------------------------------
-// 
+//
 
 `timescale 1ns/100ps
 
@@ -75,7 +75,7 @@ always @ (posedge apb_pclk)
               32'h00000000:
                  R <= apb_pwdata[7:0];
               32'h00000001:
-                 casez (apb_pwdata[1:0]) 
+                 casez (apb_pwdata[1:0])
                    2'b00: R <= R;
                    2'b01: R <= R + 1;
                    2'b10: R <= R - 1;
@@ -85,7 +85,7 @@ always @ (posedge apb_pclk)
          end
          else begin
             casez (pr_addr)
-              32'h00000000: pr_data <= {24'h0, R}; 
+              32'h00000000: pr_data <= {24'h0, R};
               default: pr_data <= 32'h0;
             endcase
             // #1;
@@ -96,5 +96,3 @@ always @ (posedge apb_pclk)
 end
 
 endmodule
-
-

--- a/test/examples/simple/registers/vertical_reuse/blk_dut.vhd
+++ b/test/examples/simple/registers/vertical_reuse/blk_dut.vhd
@@ -1,0 +1,106 @@
+--
+-- -------------------------------------------------------------
+--    Copyright 2004-2011 Synopsys, Inc.
+--    Copyright 2010 Mentor Graphics Corporation
+--    All Rights Reserved Worldwide
+--
+--    Licensed under the Apache License, Version 2.0 (the
+--    "License"); you may not use this file except in
+--    compliance with the License.  You may obtain a copy of
+--    the License at
+--
+--        http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in
+--    writing, software distributed under the License is
+--    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+--    CONDITIONS OF ANY KIND, either express or implied.  See
+--    the License for the specific language governing
+--    permissions and limitations under the License.
+-- -------------------------------------------------------------
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity blk_dut is
+
+  generic (
+    BASE_ADDR : natural := 0);
+
+  port (
+    apb_pclk    : in  std_logic;
+    apb_paddr   : in  unsigned(31 downto 0);
+    apb_psel    : in  std_logic;
+    apb_penable : in  std_logic;
+    apb_pwrite  : in  std_logic;
+    apb_prdata  : out std_logic_vector(31 downto 0);
+    apb_pwdata  : in  std_logic_vector(31 downto 0);
+    rst         : in  std_logic
+    );
+
+end blk_dut;
+
+architecture bhv of blk_dut is
+
+  signal R        : unsigned(7 downto 0);
+  signal pr_data  : std_logic_vector(31 downto 0);
+  signal pr_addr  : unsigned(31 downto 0);
+  signal in_range : boolean;
+
+begin
+
+  process (apb_paddr)
+  begin
+    pr_addr  <= apb_paddr - BASE_ADDR;
+    in_range <= false;
+    if (apb_paddr - BASE_ADDR) < 16#100# then
+      in_range <= true;
+    end if;
+  end process;
+
+  process (apb_penable, apb_psel, apb_pwrite, in_range, pr_data)
+  begin
+    if (apb_psel = '1' and apb_penable = '1' and apb_pwrite = '0' and in_range) then
+      apb_prdata <= pr_data;
+    else
+      apb_prdata <= (others => 'Z');
+    end if;
+  end process;
+
+  process (apb_pclk, rst)
+  begin
+    if rst = '1' then
+      R       <= (others => '0');
+      pr_data <= (others => '0');
+    elsif rising_edge(apb_pclk) then
+      -- Wait for a SETUP+READ or ENABLE+WRITE cycle
+      if (apb_psel = '1' and apb_penable = apb_pwrite) then
+        pr_data <= (others => '0');
+        if (apb_pwrite = '1') then
+          -- report "Writing";
+          case pr_addr is
+            when x"00000000" => R <= unsigned(apb_pwdata(7 downto 0));
+            when x"00000001" =>
+              case apb_pwdata(1 downto 0) is
+                when "00"   => R <= R;
+                when "01"   => R <= R + 1;
+                when "10"   => R <= R - 1;
+                when "11"   => R <= (others => '0');
+                when others => null;
+              end case;
+            when others => null;
+          end case;
+        else
+          -- report "Reading";
+          case pr_addr is
+            when x"00000000" => pr_data <= std_logic_vector(resize(R, 32));
+            when others      => pr_data <= (others => '0');
+          end case;
+        end if;
+      end if;
+    end if;
+  end process;
+
+end bhv;

--- a/test/examples/simple/registers/vertical_reuse/sys_dut.sv
+++ b/test/examples/simple/registers/vertical_reuse/sys_dut.sv
@@ -65,4 +65,3 @@ end
 `endif
 
 endmodule
-

--- a/test/examples/simple/registers/vertical_reuse/sys_dut.vhd
+++ b/test/examples/simple/registers/vertical_reuse/sys_dut.vhd
@@ -1,0 +1,73 @@
+--
+-- -------------------------------------------------------------
+--    Copyright 2010 Mentor Graphics Corporation
+--    Copyright 2004-2011 Synopsys, Inc.
+--    Copyright 2019-2020 Tuomas Poikela (tpoikela)
+--    All Rights Reserved Worldwide
+--
+--    Licensed under the Apache License, Version 2.0 (the
+--    "License"); you may not use this file except in
+--    compliance with the License.  You may obtain a copy of
+--    the License at
+--
+--        http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in
+--    writing, software distributed under the License is
+--    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+--    CONDITIONS OF ANY KIND, either express or implied.  See
+--    the License for the specific language governing
+--    permissions and limitations under the License.
+-- -------------------------------------------------------------
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity sys_dut is
+  generic (
+    BASE_ADDR : natural := 16#100#;
+    NUM_BLKS  : natural := 2);
+  port (
+    apb_pclk    : in  std_logic;
+    apb_paddr   : in  unsigned(31 downto 0);
+    apb_psel    : in  std_logic;
+    apb_penable : in  std_logic;
+    apb_pwrite  : in  std_logic;
+    apb_prdata  : out std_logic_vector(31 downto 0);
+    apb_pwdata  : in  std_logic_vector(31 downto 0);
+    rst : in std_logic
+    );
+end sys_dut;
+
+architecture structural of sys_dut is
+begin
+
+  b1 : entity work.blk_dut
+    generic map (
+      BASE_ADDR => BASE_ADDR)
+    port map (
+      apb_pclk    => apb_pclk,
+      apb_paddr   => apb_paddr,
+      apb_psel    => apb_psel,
+      apb_penable => apb_penable,
+      apb_pwrite  => apb_pwrite,
+      apb_prdata  => apb_prdata,
+      apb_pwdata  => apb_pwdata,
+      rst         => rst);
+
+  b2 : entity work.blk_dut
+    generic map (
+      BASE_ADDR => BASE_ADDR+16#100#)
+    port map (
+      apb_pclk    => apb_pclk,
+      apb_paddr   => apb_paddr,
+      apb_psel    => apb_psel,
+      apb_penable => apb_penable,
+      apb_pwrite  => apb_pwrite,
+      apb_prdata  => apb_prdata,
+      apb_pwdata  => apb_pwdata,
+      rst         => rst);
+
+end structural;


### PR DESCRIPTION
This pull requests adds a VHDL DUT to the `test/examples/simple/registers/models/fifo_reg` test and thus lets pure VHDL simulators (tried with GHDL and Mentor Questa) run `uvm-python`.

Run with `make SIM=ghdl TOPLEVEL_LANG=vhdl` or `make SIM=questa TOPLEVEL_LANG=vhdl`.
Using Cadence Xcelium does not work because of https://github.com/cocotb/cocotb/issues/1076.

(I also added VHDL DUTs to `test/examples/simple/registers/vertical_reuse` but this test fails already with the existing SystemVerilog setup, and VHDL is no different.)

A logfile is at https://gist.github.com/cmarqu/86f7a7588b5053dfae044ee5d7e1223c