### PR TITLE
Fixing typo in uvm_reg_block.py

### DIFF
--- a/src/uvm/reg/uvm_reg_block.py
+++ b/src/uvm/reg/uvm_reg_block.py
@@ -1300,7 +1300,7 @@ class UVMRegBlock(UVMObject):
 
             if len(parent_paths) == 0:
                 if hdl_path != "":
-                    paths.push_back(hdl_path)
+                    paths.append(hdl_path)
                 continue
 
             for j in range(len(parent_paths)):


### PR DESCRIPTION
 - get_full_hdl_path() was using push_back instead of append for list.