### PR TITLE
Adding __repr__() method to object_utils

### DIFF
--- a/src/uvm/macros/uvm_object_defines.py
+++ b/src/uvm/macros/uvm_object_defines.py
@@ -16,6 +16,7 @@ def uvm_object_utils(T):
     m_uvm_object_registry_internal(T,Ts)
     m_uvm_object_create_func(T, Ts)
     m_uvm_get_type_name_func(T, Ts)
+    m_uvm_object_repr_func(T, Ts)
     return T
 
 
@@ -73,6 +74,13 @@ def m_uvm_object_create_func(T,S):
     def create(self, name=""):
         return T(name)
     setattr(T, 'create', create)
+
+
+def m_uvm_object_repr_func(T,S):
+    def __repr__(self):
+        return T.convert2string(self)
+    if hasattr(T, 'convert2string'):
+        setattr(T, '__repr__', __repr__)
 
 
 # Needed to make uvm_field_* macros work with similar args as in SV,


### PR DESCRIPTION
 - added m_uvm_object_repr_func() to uvm_object_utils.  This checks if the class
   has a convert2string method and inserts __repr__(self) that calls convert2string.
   Purely to be lazy and avoid typing.